### PR TITLE
Fixed hang on bad connection

### DIFF
--- a/sysfs_w1.cpp
+++ b/sysfs_w1.cpp
@@ -31,7 +31,7 @@ TMaybe<float> TSysfsOnewireDevice::ReadTemperature() const
     file.open(fileName.c_str());
     if (file.is_open()) {
         std::string sLine;
-        while (!file.eof()) {
+        while (file.good()) {
             getline(file, sLine);
             size_t tpos;
             if (sLine.find("crc=")!=std::string::npos) {


### PR DESCRIPTION
When connection of 1-Wire sensor is bad, daemon may hanged. The
reason is that the file reading continues indefinitely becouse EOF
never reached (Linux rewrite file and daemon trying read after file
end).

The solution is to check whether the file can be read and not wait
for EOF.