### PR TITLE
remove g++ build dependency to allow cross-build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Evgeny Boger <boger@contactless.ru>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 10), pkg-config, g++, libwbmqtt1-dev (>= 0.2), libwbmqtt1-test-utils (>= 0.2)
+Build-Depends: debhelper (>= 10), pkg-config, libwbmqtt1-dev (>= 0.2), libwbmqtt1-test-utils (>= 0.2)
 
 Package: wb-mqtt-w1
 Architecture: any


### PR DESCRIPTION
as per https://www.debian.org/doc/manuals/maint-guide/dreq.ru.html,
"Some packages like gcc and make which are required by the build-essential package are implied"