### PR TITLE
Scan bus masters during every poll cycle

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-w1 (2.2.1) stable; urgency=medium
+
+  * Scan bus masters during every poll cycle, so restarting of 
+    the service after hardware configuration change is not needed any more.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Mon, 13 Dec 2021 10:49:56 +0500
+
 wb-mqtt-w1 (2.2.0) unstable; urgency=medium
 
   * Update dependency on libwbmqtt1 to support fixed libmosquitto facade

--- a/sysfs_w1.h
+++ b/sysfs_w1.h
@@ -38,10 +38,10 @@ public:
     const std::string& GetId() const;
 
     /**
-     * @brief Get temperature. Throws TOneWireReadErrorException if readed value is
+     * @brief Get temperature. Throws TOneWireReadErrorException if read value is
      * incorrect.
      *
-     * @return double readed temperature in Celsius degrees
+     * @return double read temperature in Celsius degrees
      */
     double GetTemperature() const;
 
@@ -51,12 +51,12 @@ public:
     PresenceStatus GetStatus() const;
 
     /**
-     * @brief Mark thermomerer as disconnected. It can be deleted during next search cycle.
+     * @brief Mark thermometer as disconnected. It can be deleted during next search cycle.
      */
     void MarkAsDisconnected();
 
     /**
-     * @brief The thermometer is found again durin search cycle.
+     * @brief The thermometer is found again during search cycle.
      *        Set directory holding thermometer's folder in sysfs.
      *        The function provides hot switching between buses.
      * 
@@ -97,15 +97,9 @@ public:
     std::vector<std::shared_ptr<TSysfsOneWireThermometer>> RescanBusAndRead();
 
 private:
-    struct TBusMaster
-    {
-        std::string Dir;
-        bool        SupportsBulkRead;
-    };
-
-    std::vector<TBusMaster> BusMasters;
-    WBMQTT::TLogger&        DebugLogger;
-    WBMQTT::TLogger&        ErrorLogger;
+    std::string      DevicesDir;
+    WBMQTT::TLogger& DebugLogger;
+    WBMQTT::TLogger& ErrorLogger;
 
     std::unordered_map<std::string,  std::shared_ptr<TSysfsOneWireThermometer>> Devices;
 };


### PR DESCRIPTION
Restarting of the service after hardware configuration change is not needed any more.