### PR TITLE
Fix service unit

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-w1 (2.2.3) stable; urgency=medium
+
+  * Fix service unit
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 11 Oct 2022 14:52:58 +0500
+
 wb-mqtt-w1 (2.2.2) stable; urgency=medium
 
   * Fix service restart limits

--- a/debian/wb-mqtt-w1.service
+++ b/debian/wb-mqtt-w1.service
@@ -2,13 +2,13 @@
 Description=Kernel 1-Wire MQTT driver for WB-HomA
 Wants=wb-hwconf-manager.service wb-modules.service
 After=network.target wb-hwconf-manager.service wb-modules.service
+StartLimitIntervalSec=0
+StartLimitBurst=0
 
 [Service]
 Type=simple
 Restart=always
 RestartSec=20
-StartLimitIntervalSec=0
-StartLimitBurst=0
 User=root
 ExecStart=/usr/bin/wb-mqtt-w1
 


### PR DESCRIPTION
На bullseye ругается так
```
окт 11 09:48:03 wirenboard-A3FMXHSO systemd[1]: /lib/systemd/system/wb-mqtt-w1.service:10: Unknown key name 'StartLimitIntervalSec' in section 'Service', ignoring.
```