### PR TITLE
fix build error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-mqtt-w1 (2.2.3+nmu1) UNRELEASED; urgency=medium
+wb-mqtt-w1 (2.2.4) stable; urgency=medium
 
   * fix build error
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-w1 (2.2.3+nmu1) UNRELEASED; urgency=medium
+
+  * fix build error
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 14 Oct 2022 03:24:36 -0400
+
 wb-mqtt-w1 (2.2.3) stable; urgency=medium
 
   * Fix service unit

--- a/sysfs_w1.h
+++ b/sysfs_w1.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Build failed with gcc 11.3.0:
```
sysfs_w1.h:97:22: error: 'shared_ptr' is not a member of 'std'
   97 |     std::vector<std::shared_ptr<TSysfsOneWireThermometer>> RescanBusAndRead();
      |                      ^~~~~~~~~~
sysfs_w1.h:9:1: note: 'std::shared_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
    8 | #include <wblib/log.h>
  +++ |+#include <memory>
    9 |
```