### PR TITLE
Fix clang-tidy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ debian/\.debhelper/
 debian/wb-homa-w1/
 debian/wb-mqtt-w1/
 *.log
+*.buildinfo
+*.changes
 *.debhelper
 debian/*.substvars
 test/wb-homa-w1-test
@@ -11,6 +13,7 @@ wb-homa-w1
 wb-mqtt-w1
 debhelper-build-stamp
 debian/files
+compile_commands.json
 
 ### Visual Studio Code ###
 .vscode

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-w1 (2.2.9) stable; urgency=medium
+
+  * Fix clang-tidy, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 30 Jan 2024 10:30:00 +0400
+
 wb-mqtt-w1 (2.2.8) stable; urgency=medium
 
   * Fix clang-format, no functional changes

--- a/test/utils.h
+++ b/test/utils.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <iomanip>
 #include <sstream>
 #include <string>
+#include <vector>
 
 inline void HexDump(std::stringstream& output, const std::vector<uint8_t>& value)
 {


### PR DESCRIPTION
```sh
$ wbdev compiledb ./clang-tidy-subdirs.sh .
...
/home/sikmir/wbdev/go/src/github.com/contactless/wb-mqtt-w1/test/utils.h:6:59: error: no template named 'vector' in namespace 'std' [clang-diagnostic-error]
inline void HexDump(std::stringstream& output, const std::vector<uint8_t>& value)
                                                          ^
/home/sikmir/wbdev/go/src/github.com/contactless/wb-mqtt-w1/test/utils.h:10:50: error: no member named 'setfill' in namespace 'std' [clang-diagnostic-error]
    output << std::hex << std::uppercase << std::setfill('0');
                                                 ^
/home/sikmir/wbdev/go/src/github.com/contactless/wb-mqtt-w1/test/utils.h:17:24: error: no member named 'setw' in namespace 'std' [clang-diagnostic-error]
        output << std::setw(2) << int(b);
                       ^
/home/sikmir/wbdev/go/src/github.com/contactless/wb-mqtt-w1/test/utils.h:22:39: error: no template named 'vector' in namespace 'std' [clang-diagnostic-error]
inline std::string HexDump(const std::vector<uint8_t>& value)
                                      ^
```