### PR TITLE
Add coverage report generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.o
+*.gcda
+*.gcno
 debian/\.debhelper/
 debian/wb-homa-w1/
 debian/wb-mqtt-w1/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@ buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
                defaultStyleCheckDirs: '.',
                defaultRunCoverage: false,
-               defaultCoverageMin: '78'
+               defaultCoverageMin: '59'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
 buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
-               defaultStyleCheckDirs: '.'
+               defaultStyleCheckDirs: '.',
+               defaultRunCoverage: false,
+               defaultCoverageMin: '78'

--- a/Makefile
+++ b/Makefile
@@ -21,20 +21,20 @@ else
 	LDFLAGS += --coverage
 endif
 
-W1_SOURCES= 					\
-			sysfs_w1.cpp		\
-			onewire_driver.cpp 	\
-			file_utils.cpp		\
-			threaded_runner.cpp \
+W1_SOURCES= \
+	sysfs_w1.cpp        \
+	onewire_driver.cpp  \
+	file_utils.cpp      \
+	threaded_runner.cpp \
 
 W1_OBJECTS=$(W1_SOURCES:.cpp=.o)
 W1_BIN=wb-mqtt-w1
 
-W1_TEST_SOURCES= 							\
-			$(TEST_DIR)/test_main.cpp		\
-			$(TEST_DIR)/sysfs_w1_test.cpp	\
-			$(TEST_DIR)/onewire_driver_test.cpp	\
-			
+W1_TEST_SOURCES= \
+	$(TEST_DIR)/test_main.cpp           \
+	$(TEST_DIR)/sysfs_w1_test.cpp       \
+	$(TEST_DIR)/onewire_driver_test.cpp \
+
 TEST_DIR=test
 export TEST_DIR_ABS = $(shell pwd)/$(TEST_DIR)
 
@@ -78,8 +78,8 @@ ifneq ($(DEBUG),)
 endif
 
 clean :
-	-rm -f *.o $(W1_BIN)
-	-rm -f $(TEST_DIR)/*.o $(TEST_DIR)/$(TEST_BIN)
+	-rm -f *.{o,gcda,gcno} $(W1_BIN)
+	-rm -f $(TEST_DIR)/*.{o,gcda,gcno} $(TEST_DIR)/$(TEST_BIN)
 
 install: all
 	install -Dm0755 $(W1_BIN) -t $(DESTDIR)$(PREFIX)/bin

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ TEST_LIBS=-lgtest -lwbmqtt_test_utils
 
 VALGRIND_FLAGS = --error-exitcode=180 -q
 
-COV_REPORT ?= cov.html
-GCOVR_FLAGS := -s --html $(COV_REPORT)
+COV_REPORT ?= cov
+GCOVR_FLAGS := -s --html $(COV_REPORT).html -x $(COV_REPORT).xml
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ TEST_LIBS=-lgtest -lwbmqtt_test_utils
 VALGRIND_FLAGS = --error-exitcode=180 -q
 
 COV_REPORT ?= cov.html
-GCOVR_FLAGS := --html $(COV_REPORT)
+GCOVR_FLAGS := -s --html $(COV_REPORT)
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-w1 (2.2.13) stable; urgency=medium
+
+  * Add coverage report generation, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 26 Sep 2024 20:10:00 +0400
+
 wb-mqtt-w1 (2.2.12) stable; urgency=medium
 
   * Add dependency from libwbmqtt1-5. No functional changes

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,12 @@ Maintainer: Wiren Board team <info@wirenboard.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 10), pkg-config, libwbmqtt1-5-dev, libwbmqtt1-5-test-utils, libgtest-dev
+Build-Depends: debhelper (>= 10),
+               gcovr:all,
+               libgtest-dev,
+               libwbmqtt1-5-dev,
+               libwbmqtt1-5-test-utils,
+               pkg-config
 Homepage: https://github.com/wirenboard/wb-mqtt-w1
 
 Package: wb-mqtt-w1

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,18 @@
 #!/usr/bin/make -f
+
+COV_FAIL_UNDER := $(patsubst cov-fail-under=%,%,$(filter cov-fail-under=%,$(DEB_BUILD_OPTIONS)))
+COV_REPORT     := $(patsubst cov-report=%,%,$(filter cov-report=%,$(DEB_BUILD_OPTIONS)))
+
+ifneq ($(COV_FAIL_UNDER),)
+	MAKEFLAGS += COV_FAIL_UNDER=$(COV_FAIL_UNDER)
+endif
+ifneq ($(COV_REPORT),)
+	MAKEFLAGS += COV_REPORT=$(COV_REPORT)
+endif
+ifneq (,$(findstring debug, $(DEB_BUILD_OPTIONS)))
+	MAKEFLAGS += DEBUG=1
+endif
+
 %:
 	dh $@ --parallel
 


### PR DESCRIPTION
How to use (with devcontainer):
```sh
make test DEBUG=1
open cov.html
```
Using wbdev:
```sh
DEB_BUILD_OPTIONS="debug check cov-fail-under=78 cov-report=cov.html" ./wbdev cdeb
```

<img width="1680" alt="Näyttökuva 2024-10-1 kello 3 50 15" src="https://github.com/user-attachments/assets/402f976d-5869-42c9-8dbb-910701a549ee">
